### PR TITLE
Add remote option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Thus, all the imports have to be contained in your cell.
 In future, an option to export the current namespace (or specific variables) will be added.
 It could be implemented by pickling the Python locals and globals and then pre-pending the cell with an un-pickling script (PRs welcome!).
 
-In the latest version of manimlib (not yet released) you will be able to import everything at once using:
+In the latest version of manimlib you can import everything at once using:
 
 ```python
 from manimlib.imports import *
@@ -68,3 +68,4 @@ You can disable this behaviour using `--verbose` flag
  - `-r` or `--resolution` - control the height and width of the video player;
   this option is shared with manim and requires the resolution in following format:
   `height,width`, e.g. `%%manim Shapes -r 200,1000`
+ - `--remote` send the video with a `data:` URL instead of a local path (useful for remote notebooks like Google Colab)

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -85,7 +85,6 @@ class ManimMagics(Magics):
                 settings[arg] = False
 
         resolution_index = (
-            user_args.index('-r') if '-r' in user_args else
             user_args.index('--resolution') if '--resolution' in user_args else
             None
         )

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -98,8 +98,8 @@ class ManimMagics(Magics):
                 warn('Unable to retrieve dimensions from your resolution setting, falling back to the defaults')
         
         remote_index = (
-            user_args.index('-r') if '-r' in user_args else
-            user_args.index('--remote') if '--remote' in user_args else
+            user_args.index('-b') if '-b' in user_args else
+            user_args.index('--base64') if '--base64' in user_args else
             None
         )
         if remote_index is not None:

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -104,6 +104,7 @@ class ManimMagics(Magics):
         )
         if remote_index is not None:
             settings['remote'] = True
+            user_args.remove('--remote')
         
         silent = settings['silent']
 

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -104,7 +104,10 @@ class ManimMagics(Magics):
         )
         if remote_index is not None:
             settings['remote'] = True
-            user_args.remove('--remote')
+            if '-b' in user_args:
+                user_args.remove('-b')
+            if '--base64' in user_args:
+                user_args.remove('--base64')
         
         silent = settings['silent']
 

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 from warnings import warn
+import base64
 
 import manimlib
 from IPython import get_ipython
@@ -50,6 +51,7 @@ class ManimMagics(Magics):
         self.defaults = {
             'autoplay': True,
             'controls': True,
+            'remote': False,
             'silent': True,
             'width': 854,
             'height': 480
@@ -95,7 +97,15 @@ class ManimMagics(Magics):
                 settings['width'] = w
             except (IndexError, KeyError):
                 warn('Unable to retrieve dimensions from your resolution setting, falling back to the defaults')
-
+        
+        remote_index = (
+            user_args.index('-r') if '-r' in user_args else
+            user_args.index('--remote') if '--remote' in user_args else
+            None
+        )
+        if remote_index is not None:
+            settings['remote'] = True
+        
         silent = settings['silent']
 
         def catch_path_and_forward(lines):
@@ -148,8 +158,14 @@ class ManimMagics(Magics):
                 for k, v in settings.items()
                 if k in self.video_settings
             }
-
-            return video(relative_path, **video_settings)
+            # If in remote mode, we send with a data: url
+            if settings['remote']:
+                data = base64.b64encode(path.read_bytes()).decode()
+                data_url = "data:video/mp4;base64," + data
+                return video(data_url, **video_settings)
+            # otherwise a relative path is fine
+            else:
+                return video(relative_path, **video_settings)
         else:
             just_show_help = '-h' in user_args or '--help' in user_args
 


### PR DESCRIPTION
Adds a `--remote` option which sends the video with a `data:video/mp4;base64,` URL instead of a relative path. This is useful for when you are working on a remote machine like [Google Colab](https://colab.research.google.com) and don't have access to the filesystem. The `data:` URL sends the entire base64 encoded file in the `src` of the video HTML if the `--remote` option is passed to the cell magic. 
I have tested this on [Google Colab](https://colab.research.google.com) and it works like a charm. Would love to see this pushed so I can shorten by setup cell to just an import rather that all this code. 
Appreciate this library!