### PR TITLE
Fix false negative results, add more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
-         - choco install x264vfw
-         - choco install openshot
          - choco install ffmpeg
          # - choco install miktex.portable
          - choco install sox.portable
@@ -36,6 +34,8 @@ jobs:
          - pip3 install https://download.lfd.uci.edu/pythonlibs/t7epjj8p/pycairo-1.18.2-cp37-cp37m-win_amd64.whl --user
          # temporary workaround for https://github.com/3b1b/manim/pull/672
          - pip3 install pyreadline==2.1 --user
+  allow_failures:
+    - os: windows
 
 install:
   - pip3 install --upgrade pip || python -m pip install --upgrade pip --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,10 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
-         - choco install miniconda3
+         - choco install miniconda3 --params="'/AddToPath:1'"
          # libx264 / x265 missing from newer builds
-         - conda install x264=='1!152.20180717' ffmpeg=4.0.2 -c conda-forge
+         -  conda config --add channels conda-forge 
+         - conda install x264 ffmpeg -c conda-forge
          # - choco install miktex.portable
          - choco install sox.portable
          # https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
-           #- choco install ffmpeg
-         - choco install imagemagick.app
+         - choco install x264vfw
+         - choco install openshot
+         - choco install ffmpeg
          # - choco install miktex.portable
          - choco install sox.portable
          # https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ jobs:
     - name: "Python 3.7 on Windows"
       os: windows
       language: shell
-      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+      env: PATH=/c/Python37:/c/Python37/Scripts:/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
-         - choco install miniconda3 --params="'/AddToPath:1'"
+         - choco install miniconda3
          # libx264 / x265 missing from newer builds
          -  conda config --add channels conda-forge 
          - conda install x264 ffmpeg -c conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ jobs:
       language: shell
       before_install:
         - brew install ffmpeg
+        - brew install cairo
     - name: "Python 3.7 on Windows"
       os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,8 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
-         - choco install miniconda3
-         # libx264 / x265 missing from newer builds
-         -  conda config --add channels conda-forge 
-         - conda install x264 ffmpeg -c conda-forge
+           #- choco install ffmpeg
+         - choco install imagemagick.app
          # - choco install miktex.portable
          - choco install sox.portable
          # https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - python3 setup.py install || python setup.py install
 
 script:
-  - ipython -m pytest -- --cov=.
+  - ipython -m pytest -- --cov=. -v
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
       before_install:
         - brew install ffmpeg
         - brew install cairo
+        - pip3 install pycairo --user
     - name: "Python 3.7 on Windows"
       os: windows
       language: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - python3 setup.py install || python setup.py install
 
 script:
-  - python3 ipytest.py --cov=. -v || python ipytest.py --cov=. -v
+  - python3 ipytest.py --cov=jupyter_manim -v || python ipytest.py --cov=jupyter_manim -v
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - python3 setup.py install || python setup.py install
 
 script:
-  - ipython -m pytest -- --cov=. -v
+  - python3 ipytest.py --cov=. -v || python ipytest.py --cov=. -v
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ jobs:
          # https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo
          # https://stackoverflow.com/a/48132109/6646912
          - pip3 install https://download.lfd.uci.edu/pythonlibs/t7epjj8p/pycairo-1.18.2-cp37-cp37m-win_amd64.whl --user
+         # temporary workaround for https://github.com/3b1b/manim/pull/672
+         - pip3 install pyreadline==2.1 --user
 
 install:
   - pip3 install --upgrade pip || python -m pip install --upgrade pip --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
+         - choco install miniconda3
          # libx264 / x265 missing from newer builds
-         - choco install ffmpeg --version 3.3.1
+         - conda install x264=='1!152.20180717' ffmpeg=4.0.2 -c conda-forge
          # - choco install miktex.portable
          - choco install sox.portable
          # https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ jobs:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
          - choco install python --version 3.7.4
-         - choco install ffmpeg
+         # libx264 / x265 missing from newer builds
+         - choco install ffmpeg --version 3.3.1
          # - choco install miktex.portable
          - choco install sox.portable
          # https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo

--- a/ipytest.py
+++ b/ipytest.py
@@ -1,0 +1,18 @@
+import sys
+from IPython.core.interactiveshell import InteractiveShell
+from IPython import start_ipython
+import runpy
+
+
+def run_module(self, mod_name, where):
+    where.update(
+        runpy.run_module(
+            str(mod_name), run_name="__main__",
+            alter_sys=True
+        )
+    )
+
+
+InteractiveShell.safe_run_module = run_module
+
+result = start_ipython(['-m', 'pytest', '--'] + sys.argv[1:])

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -128,6 +128,8 @@ class ManimMagics(Magics):
             warn('Pickling failed: ' + str(e))
             yield None
         finally:
+            if not f.closed:
+                f.close()
             os.remove(f.name)
 
     def parse_arguments(self, line) -> Tuple[Dict, List]:

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -205,7 +205,6 @@ class ManimMagics(Magics):
                 enter = stack.enter_context
 
                 if settings['export_variables']:
-                    # TODO test this with pytest
                     pickle_path = enter(self.export_globals())
 
                     if pickle_path:

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -49,7 +49,7 @@ UNPICKLE_SCRIPT = """
 import pickle
 from warnings import warn
 try:
-    with open('{pickle_path}', 'rb') as f:
+    with open(r'{pickle_path}', 'rb') as f:
         objects_from_notebook = pickle.load(f)
 except pickle.PickleError as e:
     warn('Could not unpickle the global objects from the notebook', e)

--- a/jupyter_manim/__init__.py
+++ b/jupyter_manim/__init__.py
@@ -76,7 +76,7 @@ def is_pickable(obj):
 
 
 def find_ipython_frame(frames):
-    for frame in inspect.stack():
+    for frame in frames:
         if frame.filename.startswith('<ipython-input-'):
             return frame
     return None

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ pytest==5.3.0
 pytest-cov==2.5.1
 codecov
 papermill
+jupyter

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest==5.3.0
 pytest-cov==2.5.1
 codecov
+papermill

--- a/tests/test_manim.py
+++ b/tests/test_manim.py
@@ -43,6 +43,8 @@ def test_integration():
         assert cell['metadata']['papermill']['exception'] is False
 
     last_cell_outputs = output_notebook['cells'][-1]['outputs']
+    if len(last_cell_outputs) != 1:
+        print(last_cell_outputs)
     assert len(last_cell_outputs) == 1
     output_data = last_cell_outputs[0]['data']
     assert re.match(

--- a/tests/test_manim.py
+++ b/tests/test_manim.py
@@ -3,6 +3,7 @@ import pickle
 import re
 from typing import NamedTuple
 
+import pytest
 from papermill import execute_notebook
 
 from jupyter_manim import ManimMagics, find_ipython_frame
@@ -34,6 +35,7 @@ SHAPES_OUTPUT_REGEXP = r"""
 """
 
 
+@pytest.mark.manim_dependent
 def test_integration():
     output_notebook = execute_notebook(
         'Example.ipynb',
@@ -134,12 +136,14 @@ def test_help(capsys):
     assert not captured.err.strip()
 
 
+@pytest.mark.manim_dependent
 def test_cell_magic():
     magics_manager = ManimMagics()
     result = magics_manager.manim('Shapes', SHAPES_EXAMPLE)
     assert re.match(SHAPES_OUTPUT_REGEXP, result.data)
 
 
+@pytest.mark.manim_dependent
 def test_cell_base64():
     magics_manager = ManimMagics()
     result = magics_manager.manim('Shapes --base64 --low_quality', SHAPES_EXAMPLE)


### PR DESCRIPTION
Tests on Windows are failing, most likely due to FFmpeg installation issues (https://github.com/3b1b/manim/issues/669) and are allowed to fail; two Windows-specific issues were fixed:
- always close the pickle file 
- provide the file paths as a raw string